### PR TITLE
Fix login screen hanging.

### DIFF
--- a/runescape-client/src/main/java/LoginScreenAnimation.java
+++ b/runescape-client/src/main/java/LoginScreenAnimation.java
@@ -286,7 +286,7 @@ public class LoginScreenAnimation {
 			int var11;
 			int var12;
 			int var13;
-			for (var11 = 0; var11 < this.field1285 * 10000; ++var11) {
+			for (var11 = 0; var11 < this.field1285; ++var11) {
 				var12 = (int)(Math.random() * (double)var10) + var17;
 				var13 = (int)(Math.random() * (double)var16) + var16;
 				this.field1278[var12 + (var13 << 7)] = 192;


### PR DESCRIPTION
The login screen is currently hanging because the login screen animation (the two things left and right) are endlessly animating. `field1285` has a value of `100` when resolved and is multiplied by `10000` for a second time for some reason, (this is already done on line 279), causing the endless loop.

The method is called in every draw call of the login screen, causing the client to hang and not respond.